### PR TITLE
Updated Numbers to Words

### DIFF
--- a/Tests/NumbersToWords/run.js
+++ b/Tests/NumbersToWords/run.js
@@ -7,7 +7,7 @@ const { argv } = require('yargs');
 const tempFile = "test/s.js";
 const tempFileStream = fs.createWriteStream(tempFile);
 
-const arg = argv._
+const arg = argv._;
 
 if (argv._.length === 0) {
   defaultTest();
@@ -40,10 +40,10 @@ function gitTest(url) {
     }
   })
   .then(function(response) {
-    let res = response.body._readableState.buffer.head.data
-    let regex = /"content"/
-    let index = res.toString().search(regex)
-    let content = res.toString().slice(index + 11)
+    let res = response.body._readableState.buffer.head.data;
+    let regex = /"content"/;
+    let index = res.toString().search(regex);
+    let content = res.toString().slice(index + 11);
     let decodedContent = Buffer.from(content, 'base64').toString();
     runTests(decodedContent)
   })

--- a/Tests/NumbersToWords/test/test.js
+++ b/Tests/NumbersToWords/test/test.js
@@ -1,197 +1,199 @@
 const numbersToWords = require('./s.js');
 const chai = require('chai');
-const expect = chai.expect;
+const assert = chai.assert;
 const colors = require('mocha/lib/reporters/base').colors;
 colors['pending'] = '93';
 colors['green'] = '92';
 
-describe("Numbers To Words, write a function that returns an array with all the numbers from 1 through 1000 in words", function() {
+describe("Numbers To Words, write a function that returns an array with all the numbers from 1 through 1000 in words", function () {
 
-    it("should be a function", function() {
-        if(typeof numbersToWords.numbersToWords != 'function') {
+    it("should be a function", function () {
+        if (typeof numbersToWords.numbersToWords != 'function') {
             this.skip();
         }
     });
+    if (typeof numbersToWords.numbersToWords === 'function') {
 
-    if(typeof numbersToWords.numbersToWords === 'function') {
+        const results = numbersToWords.numbersToWords();
+        it("Returns an array", function () {
+            assert.isArray(results);
+        });
+        it("Return value is an array with 1000 elements", function () {
+            assert.equal(1000, results.length);
+        });
 
-    const results = numbersToWords.numbersToWords();
+        it("Returns values one-nine", function () {
+            assert.deepEqual(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'], results.slice(0, 9));
+        });
 
-    it("Return value is an array with 1000 elements", function() {
-        expect(results.length).to.equal(1000);
-    });
+        it("Returns teens (10 - 19) values", function () {
+            assert.deepEqual(['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen'], results.slice(9, 19));
+        });
 
-    it("Returns expected ones values", function() {
-        expect(results.slice(0, 9)).to.eql(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']);
-    });
+        it("Returns tens values", function () {
+            assert.equal('twenty', results[19]);
+            assert.equal('thirty', results[29]);
+            assert.equal('forty', results[39]);
+            assert.equal('fifty', results[49]);
+            assert.equal('sixty', results[59]);
+            assert.equal('seventy', results[69]);
+            assert.equal('eighty', results[79]);
+            assert.equal('ninety', results[89]);
+        });
 
-    it("Returns expected teens (10 - 19) values", function() {
-        expect(results.slice(9, 19)).to.eql(['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen']);
-    });
+        const oneHundred = ["one hundred", "one-hundred"];
+        const twoHundred = ["two hundred", "two-hundred"];
+        const threeHundred = ["three hundred", "three-hundred"];
+        const fourHundred = ["four hundred", "four-hundred"];
+        const fiveHundred = ["five hundred", "five-hundred"];
+        const sixHundred = ["six hundred", "six-hundred"];
+        const sevenHundred = ["seven hundred", "seven-hundred"];
+        const eightHundred = ["eight hundred", "eight-hundred"];
+        const nineHundred = ["nine hundred", "nine-hundred"];
+        const oneThousand = ["one thousand", "one-thousand"];
 
-    it("Returns expected tens values", function() {
-        expect(results[19]).to.eql('twenty');
-        expect(results[29]).to.eql('thirty');
-        expect(results[39]).to.eql('forty');
-        expect(results[49]).to.eql('fifty');
-        expect(results[59]).to.eql('sixty');
-        expect(results[69]).to.eql('seventy');
-        expect(results[79]).to.eql('eighty');
-        expect(results[89]).to.eql('ninety');
-    });
+        it("Returns hundreds values", function () {
+            //expect(oneHundred.includes(results[99])).to.equal(true);
+            assert.include(oneHundred, results[99]);
+            assert.include(twoHundred, results[199]);
+            assert.include(threeHundred, results[299]);
+            assert.include(fourHundred, results[399]);
+            assert.include(fiveHundred, results[499]);
+            assert.include(sixHundred, results[599]);
+            assert.include(sevenHundred, results[699]);
+            assert.include(eightHundred, results[799]);
+            assert.include(nineHundred, results[899]);
+            assert.include(oneThousand, results[999]);
+        });
 
-    const oneHundred = ["one hundred", "one-hundred"];
-    const twoHundred = ["two hundred", "two-hundred"];
-    const threeHundred = ["three hundred", "three-hundred"];
-    const fourHundred = ["four hundred", "four-hundred"];
-    const fiveHundred = ["five hundred", "five-hundred"];
-    const sixHundred =  ["six hundred", "six-hundred"];
-    const sevenHundred = ["seven hundred", "seven-hundred"];
-    const eightHundred = ["eight hundred", "eight-hundred"];
-    const nineHundred = ["nine hundred", "nine-hundred"];
-    const oneThousand = ["one thousand", "one-thousand"];
+        const oneNineteen = ["one hundred nineteen", "one-hundred-nineteen"];
+        const oneThirtyEight = ["one hundred thirty eight", "one-hundred-thirty-eight"];
+        const oneFiftySeven = ["one hundred fifty seven", "one-hundred-fifty-seven"];
+        const oneSeventyNine = ["one hundred seventy nine", "one-hundred-seventy-nine"];
+        const oneNinetyFour = ["one hundred ninety four", "one-hundred-ninety-four"];
 
-    it("Returns expected hundreds values", function() {
-        expect(oneHundred.includes(results[99])).to.equal(true);
-        expect(twoHundred.includes(results[199])).to.equal(true);
-        expect(threeHundred.includes(results[299])).to.equal(true);
-        expect(fourHundred.includes(results[399])).to.equal(true);
-        expect(fiveHundred.includes(results[499])).to.equal(true);
-        expect(sixHundred.includes(results[599])).to.equal(true);
-        expect(sevenHundred.includes(results[699])).to.equal(true);
-        expect(eightHundred.includes(results[799])).to.equal(true);
-        expect(nineHundred.includes(results[899])).to.equal(true);
-        expect(oneThousand.includes(results[999])).to.equal(true);
-    });
+        it("Returns 5 values correctly between 100 - 200", function () {
+            assert.include(oneNineteen, results[118]);
+            assert.include(oneThirtyEight, results[137]);
+            assert.include(oneFiftySeven, results[156]);
+            assert.include(oneSeventyNine, results[178]);
+            assert.include(oneNinetyFour, results[193]);
+        });
 
-    const oneNineteen = ["one hundred nineteen", "one-hundred-nineteen"];
-    const oneThirtyEight = ["one hundred thirty eight", "one-hundred-thirty-eight"];
-    const oneFiftySeven = ["one hundred fifty seven", "one-hundred-fifty-seven"];
-    const oneSeventyNine = ["one hundred seventy nine", "one-hundred-seventy-nine"];
-    const oneNinetyFour = ["one hundred ninety four", "one-hundred-ninety-four"];
+        const twoSixteen = ["two hundred sixteen", "two-hundred-sixteen"];
+        const twoFortyOne = ["two hundred forty one", "two-hundred-forty-one"];
+        const twoSixtyThree = ["two hundred sixty three", "two-hundred-sixty-three"];
+        const twoEightyTwo = ["two hundred eighty two", "two-hundred-eighty-two"];
+        const twoNinetySeven = ["two hundred ninety seven", "two-hundred-ninety-seven"];
 
-    it("Returns 5 values correctly between 100 - 200", function() {
-        expect(oneNineteen.includes(results[118])).to.equal(true);
-        expect(oneThirtyEight.includes(results[137])).to.equal(true);
-        expect(oneFiftySeven.includes(results[156])).to.equal(true);
-        expect(oneSeventyNine.includes(results[178])).to.equal(true);
-        expect(oneNinetyFour.includes(results[193])).to.equal(true);
-    });
+        it("Returns 5 values correctly between 200 - 300", function () {
+            assert.include(twoSixteen, results[215]);
+            assert.include(twoFortyOne, results[240]);
+            assert.include(twoSixtyThree, results[262]);
+            assert.include(twoEightyTwo, results[281]);
+            assert.include(twoNinetySeven, results[296]);
+        });
 
-    const twoSixteen = ["two hundred sixteen", "two-hundred-sixteen"];
-    const twoFortyOne = ["two hundred forty one", "two-hundred-forty-one"];
-    const twoSixtyThree = ["two hundred sixty three", "two-hundred-sixty-three"];
-    const twoEightyTwo = ["two hundred eighty two", "two-hundred-eighty-two"];
-    const twoNinetySeven = ["two hundred ninety seven", "two-hundred-ninety-seven"];
+        const threeHundredNine = ["three hundred nine", "three-hundred-nine"];
+        const threeSeventeen = ["three hundred seventeen", "three-hundred-seventeen"];
+        const threeThirtyEight = ["three hundred thirty eight", "three-hundred-thirty-eight"];
+        const threeFiftyTwo = ["three hundred fifty two", "three-hundred-fifty-two"];
+        const threeSeventySeven = ["three hundred seventy seven", "three-hundred-seventy-seven"];
 
-    it("Returns 5 values correctly between 200 - 300", function() {
-        expect(twoSixteen.includes(results[215])).to.equal(true);
-        expect(twoFortyOne.includes(results[240])).to.equal(true);
-        expect(twoSixtyThree.includes(results[262])).to.equal(true);
-        expect(twoEightyTwo.includes(results[281])).to.equal(true);
-        expect(twoNinetySeven.includes(results[296])).to.equal(true);
-    });
+        it("Returns 5 values correctly between 300 - 400", function () {
+            assert.include(threeHundredNine, results[308]);
+            assert.include(threeSeventeen, results[316]);
+            assert.include(threeThirtyEight, results[337]);
+            assert.include(threeFiftyTwo, results[351]);
+            assert.include(threeSeventySeven, results[376]);
+        });
 
-    const threeHundredNine = ["three hundred nine", "three-hundred-nine"];
-    const threeSeventeen = ["three hundred seventeen", "three-hundred-seventeen"];
-    const threeThirtyEight = ["three hundred thirty eight", "three-hundred-thirty-eight"];
-    const threeFiftyTwo = ["three hundred fifty two", "three-hundred-fifty-two"];
-    const threeSeventySeven = ["three hundred seventy seven", "three-hundred-seventy-seven"];
+        const fourHundredFifteen = ["four hundred fifteen", "four-hundred-fifteen"];
+        const fourThirtyNine = ["four hundred thirty nine", "four-hundred-thirty-nine"];
+        const fourSixtyOne = ["four hundred sixty one", "four-hundred-sixty-one"];
+        const fourEightySeven = ["four hundred eighty seven", "four-hundred-eighty-seven"];
+        const fourNinetyOne = ["four hundred ninety one", "four-hundred-ninety-one"];
 
-    it("Returns 5 values correctly between 300 - 400", function() {
-        expect(threeHundredNine.includes(results[308])).to.equal(true);
-        expect(threeSeventeen.includes(results[316])).to.equal(true);
-        expect(threeThirtyEight.includes(results[337])).to.equal(true);
-        expect(threeFiftyTwo.includes(results[351])).to.equal(true);
-        expect(threeSeventySeven.includes(results[376])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 400 - 500", function () {
+            assert.include(fourHundredFifteen, results[414]);
+            assert.include(fourThirtyNine, results[438]);
+            assert.include(fourSixtyOne, results[460]);
+            assert.include(fourEightySeven, results[486]);
+            assert.include(fourNinetyOne, results[490]);
+        });
 
-    const fourHundredFifteen = ["four hundred fifteen", "four-hundred-fifteen"];
-    const fourThirtyNine = ["four hundred thirty nine", "four-hundred-thirty-nine"];
-    const fourSixtyOne = ["four hundred sixty one", "four-hundred-sixty-one"];
-    const fourEightySeven = ["four hundred eighty seven", "four-hundred-eighty-seven"];
-    const fourNinetyOne = ["four hundred ninety one", "four-hundred-ninety-one"];
+        const fiveHundredNine = ["five hundred nine", "five-hundred-nine"];
+        const fiveNineteen = ["five hundred nineteen", "five-hundred-nineteen"];
+        const fiveSixtySeven = ["five hundred sixty seven", "five-hundred-sixty-seven"];
+        const fiveEightyNine = ["five hundred eighty nine", "five-hundred-eighty-nine"];
+        const fiveNinetyEight = ["five hundred ninety eight", "five-hundred-ninety-eight"];
 
-    it("Returns 5 values correctly between 400 - 500", function() {
-        expect(fourHundredFifteen.includes(results[414])).to.equal(true);
-        expect(fourThirtyNine.includes(results[438])).to.equal(true);
-        expect(fourSixtyOne.includes(results[460])).to.equal(true);
-        expect(fourEightySeven.includes(results[486])).to.equal(true);
-        expect(fourNinetyOne.includes(results[490])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 500 - 600", function () {
+            assert.include(fiveHundredNine, results[508]);
+            assert.include(fiveNineteen, results[518]);
+            assert.include(fiveSixtySeven, results[566]);
+            assert.include(fiveEightyNine, results[588]);
+            assert.include(fiveNinetyEight, results[597]);
+        });
 
-    const fiveHundredNine = ["five hundred nine", "five-hundred-nine"];
-    const fiveNineteen = ["five hundred nineteen", "five-hundred-nineteen"];
-    const fiveSixtySeven = ["five hundred sixty seven", "five-hundred-sixty-seven"];
-    const fiveEightyNine = ["five hundred eighty nine", "five-hundred-eighty-nine"];
-    const fiveNinetyEight = ["five hundred ninety eight", "five-hundred-ninety-eight"];
+        const sixHundredSeven = ["six hundred seven", "six-hundred-seven"];
+        const sixTwentyNine = ["six hundred twenty nine", "six-hundred-twenty-nine"];
+        const sixFortySix = ["six hundred forty six", "six-hundred-forty-six"];
+        const sixSixtyEight = ["six hundred sixty eight", "six-hundred-sixty-eight"];
+        const sixEightyTwo = ["six hundred eighty two", "six-hundred-eighty-two"];
 
-    it("Returns 5 values correctly between 500 - 600", function() {
-        expect(fiveHundredNine.includes(results[508])).to.equal(true);
-        expect(fiveNineteen.includes(results[518])).to.equal(true);
-        expect(fiveSixtySeven.includes(results[566])).to.equal(true);
-        expect(fiveEightyNine.includes(results[588])).to.equal(true);
-        expect(fiveNinetyEight.includes(results[597])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 600 - 700", function () {
+            assert.include(sixHundredSeven, results[606]);
+            assert.include(sixTwentyNine, results[628]);
+            assert.include(sixFortySix, results[645]);
+            assert.include(sixSixtyEight, results[667]);
+            assert.include(sixEightyTwo, results[681]);
+        });
 
-    const sixHundredSeven = ["six hundred seven", "six-hundred-seven"];
-    const sixTwentyNine = ["six hundred twenty nine", "six-hundred-twenty-nine"];
-    const sixFortySix = ["six hundred forty six", "six-hundred-forty-six"];
-    const sixSixtyEight = ["six hundred sixty eight", "six-hundred-sixty-eight"];
-    const sixEightyTwo = ["six hundred eighty two", "six-hundred-eighty-two"];
+        const sevenThirtyTwo = ["seven hundred thirty two", "seven-hundred-thirty-two"];
+        const sevenFortyOne = ["seven hundred forty one", "seven-hundred-forty-one"];
+        const sevenSixtyEight = ["seven hundred sixty eight", "seven-hundred-sixty-eight"];
+        const sevenNinetySix = ["seven hundred ninety six", "seven-hundred-ninety-six"];
+        const sevenNinetyNine = ["seven hundred ninety nine", "seven-hundred-ninety-nine"];
 
-    it("Returns 5 values correctly between 600 - 700", function() {
-        expect(sixHundredSeven.includes(results[606])).to.equal(true);
-        expect(sixTwentyNine.includes(results[628])).to.equal(true);
-        expect(sixFortySix.includes(results[645])).to.equal(true);
-        expect(sixSixtyEight.includes(results[667])).to.equal(true);
-        expect(sixEightyTwo.includes(results[681])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 700 - 800", function () {
+            assert.include(sevenThirtyTwo, results[731]);
+            assert.include(sevenFortyOne, results[740]);
+            assert.include(sevenSixtyEight, results[767]);
+            assert.include(sevenNinetySix, results[795]);
+            assert.include(sevenNinetyNine, results[798]);
+        });
 
-    const sevenThirtyTwo = ["seven hundred thirty two", "seven-hundred-thirty-two"];
-    const sevenFortyOne = ["seven hundred forty one", "seven-hundred-forty-one"];
-    const sevenSixtyEight = ["seven hundred sixty eight", "seven-hundred-sixty-eight"];
-    const sevenNinetySix = ["seven hundred ninety six", "seven-hundred-ninety-six"];
-    const sevenNinetyNine = ["seven hundred ninety nine", "seven-hundred-ninety-nine"];
+        const eightHundredEight = ["eight hundred eight", "eight-hundred-eight"];
+        const eightThirtySeven = ["eight hundred thirty seven", "eight-hundred-thirty-seven"];
+        const eightFiftyNine = ["eight hundred fifty nine", "eight-hundred-fifty-nine"];
+        const eightSeventySix = ["eight hundred seventy six", "eight-hundred-seventy-six"];
+        const eightEightyEight = ["eight hundred eighty eight", "eight-hundred-eighty-eight"];
 
-    it("Returns 5 values correctly between 700 - 800", function() {
-        expect(sevenThirtyTwo.includes(results[731])).to.equal(true);
-        expect(sevenFortyOne.includes(results[740])).to.equal(true);
-        expect(sevenSixtyEight.includes(results[767])).to.equal(true);
-        expect(sevenNinetySix.includes(results[795])).to.equal(true);
-        expect(sevenNinetyNine.includes(results[798])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 800 - 900", function () {
+            assert.include(eightHundredEight, results[807]);
+            assert.include(eightThirtySeven, results[836]);
+            assert.include(eightFiftyNine, results[858]);
+            assert.include(eightSeventySix, results[875]);
+            assert.include(eightEightyEight, results[887]);
+        });
 
-    const eightHundredEight = ["eight hundred eight", "eight-hundred-eight"];
-    const eightThirtySeven = ["eight hundred thirty seven", "eight-hundred-thirty-seven"];
-    const eightFiftyNine = ["eight hundred fifty nine", "eight-hundred-fifty-nine"];
-    const eightSeventySix = ["eight hundred seventy six", "eight-hundred-seventy-six"];
-    const eightEightyEight = ["eight hundred eighty eight", "eight-hundred-eighty-eight"];
+        const nineHundredTwo = ["nine hundred two", "nine-hundred-two"];
+        const nineSeventeen = ["nine hundred seventeen", "nine-hundred-seventeen"];
+        const nineFiftyFive = ["nine hundred fifty five", "nine-hundred-fifty-five"];
+        const nineSeventyNine = ["nine hundred seventy nine", "nine-hundred-seventy-nine"];
+        const nineEightyEight = ["nine hundred eighty eight", "nine-hundred-eighty-eight"];
 
-    it("Returns 5 values correctly between 800 - 900", function() {
-        expect(eightHundredEight.includes(results[807])).to.equal(true);
-        expect(eightThirtySeven.includes(results[836])).to.equal(true);
-        expect(eightFiftyNine.includes(results[858])).to.equal(true);
-        expect(eightSeventySix.includes(results[875])).to.equal(true);
-        expect(eightEightyEight.includes(results[887])).to.equal(true)
-    });
+        it("Returns 5 values correctly between 900 - 999", function () {
+            assert.include(nineHundredTwo, results[901]);
+            assert.include(nineSeventeen, results[916]);
+            assert.include(nineFiftyFive, results[954]);
+            assert.include(nineSeventyNine, results[978]);
+            assert.include(nineEightyEight, results[987]);
+        });
 
-    const nineHundredTwo = ["nine hundred two", "nine-hundred-two"];
-    const nineSeventeen = ["nine hundred seventeen", "nine-hundred-seventeen"];
-    const nineFiftyFive = ["nine hundred fifty five", "nine-hundred-fifty-five"];
-    const nineSeventyNine = ["nine hundred seventy nine", "nine-hundred-seventy-nine"];
-    const nineEightyEight = ["nine hundred eighty eight", "nine-hundred-eighty-eight"];
-
-    it("Returns 5 values correctly between 900 - 999", function() {
-        expect(nineHundredTwo.includes(results[901])).to.equal(true);
-        expect(nineSeventeen.includes(results[916])).to.equal(true);
-        expect(nineFiftyFive.includes(results[954])).to.equal(true);
-        expect(nineSeventyNine.includes(results[978])).to.equal(true);
-        expect(nineEightyEight.includes(results[987])).to.equal(true)
-    });
-
-    it("Last value in results is 1000", function() {
-        expect(oneThousand.includes(results[999])).to.equal(true)
-    })
-}
+        it("Last value in results is 1000", function () {
+            assert.include(oneThousand, results[999]);
+        })
+    }
 });

--- a/Tests/NumbersToWords/test/test.js
+++ b/Tests/NumbersToWords/test/test.js
@@ -19,15 +19,15 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Return value is an array with 1000 elements", function() {
         expect(results.length).to.equal(1000);
-    })
+    });
 
     it("Returns expected ones values", function() {
         expect(results.slice(0, 9)).to.eql(['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']);
-    })
+    });
 
     it("Returns expected teens (10 - 19) values", function() {
         expect(results.slice(9, 19)).to.eql(['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen']);
-    })
+    });
 
     it("Returns expected tens values", function() {
         expect(results[19]).to.eql('twenty');
@@ -38,7 +38,7 @@ describe("Numbers To Words, write a function that returns an array with all the 
         expect(results[69]).to.eql('seventy');
         expect(results[79]).to.eql('eighty');
         expect(results[89]).to.eql('ninety');
-    })
+    });
 
     const oneHundred = ["one hundred", "one-hundred"];
     const twoHundred = ["two hundred", "two-hundred"];
@@ -62,7 +62,7 @@ describe("Numbers To Words, write a function that returns an array with all the 
         expect(eightHundred.includes(results[799])).to.equal(true);
         expect(nineHundred.includes(results[899])).to.equal(true);
         expect(oneThousand.includes(results[999])).to.equal(true);
-    })
+    });
 
     const oneNineteen = ["one hundred nineteen", "one-hundred-nineteen"];
     const oneThirtyEight = ["one hundred thirty eight", "one-hundred-thirty-eight"];
@@ -76,13 +76,13 @@ describe("Numbers To Words, write a function that returns an array with all the 
         expect(oneFiftySeven.includes(results[156])).to.equal(true);
         expect(oneSeventyNine.includes(results[178])).to.equal(true);
         expect(oneNinetyFour.includes(results[193])).to.equal(true);
-    })
+    });
 
     const twoSixteen = ["two hundred sixteen", "two-hundred-sixteen"];
     const twoFortyOne = ["two hundred forty one", "two-hundred-forty-one"];
     const twoSixtyThree = ["two hundred sixty three", "two-hundred-sixty-three"];
     const twoEightyTwo = ["two hundred eighty two", "two-hundred-eighty-two"];
-    const twoNinetySeven = ["two hundred ninety seven", "two-hundred-ninety-seven"]
+    const twoNinetySeven = ["two hundred ninety seven", "two-hundred-ninety-seven"];
 
     it("Returns 5 values correctly between 200 - 300", function() {
         expect(twoSixteen.includes(results[215])).to.equal(true);
@@ -90,7 +90,7 @@ describe("Numbers To Words, write a function that returns an array with all the 
         expect(twoSixtyThree.includes(results[262])).to.equal(true);
         expect(twoEightyTwo.includes(results[281])).to.equal(true);
         expect(twoNinetySeven.includes(results[296])).to.equal(true);
-    })
+    });
 
     const threeHundredNine = ["three hundred nine", "three-hundred-nine"];
     const threeSeventeen = ["three hundred seventeen", "three-hundred-seventeen"];
@@ -100,11 +100,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 300 - 400", function() {
         expect(threeHundredNine.includes(results[308])).to.equal(true);
-        expect(threeSeventeen.includes(results[316])).to.equal(true)
-        expect(threeThirtyEight.includes(results[337])).to.equal(true)
-        expect(threeFiftyTwo.includes(results[351])).to.equal(true)
+        expect(threeSeventeen.includes(results[316])).to.equal(true);
+        expect(threeThirtyEight.includes(results[337])).to.equal(true);
+        expect(threeFiftyTwo.includes(results[351])).to.equal(true);
         expect(threeSeventySeven.includes(results[376])).to.equal(true)
-    })
+    });
 
     const fourHundredFifteen = ["four hundred fifteen", "four-hundred-fifteen"];
     const fourThirtyNine = ["four hundred thirty nine", "four-hundred-thirty-nine"];
@@ -114,11 +114,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 400 - 500", function() {
         expect(fourHundredFifteen.includes(results[414])).to.equal(true);
-        expect(fourThirtyNine.includes(results[438])).to.equal(true)
-        expect(fourSixtyOne.includes(results[460])).to.equal(true)
-        expect(fourEightySeven.includes(results[486])).to.equal(true)
+        expect(fourThirtyNine.includes(results[438])).to.equal(true);
+        expect(fourSixtyOne.includes(results[460])).to.equal(true);
+        expect(fourEightySeven.includes(results[486])).to.equal(true);
         expect(fourNinetyOne.includes(results[490])).to.equal(true)
-    })
+    });
 
     const fiveHundredNine = ["five hundred nine", "five-hundred-nine"];
     const fiveNineteen = ["five hundred nineteen", "five-hundred-nineteen"];
@@ -128,11 +128,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 500 - 600", function() {
         expect(fiveHundredNine.includes(results[508])).to.equal(true);
-        expect(fiveNineteen.includes(results[518])).to.equal(true)
-        expect(fiveSixtySeven.includes(results[566])).to.equal(true)
-        expect(fiveEightyNine.includes(results[588])).to.equal(true)
+        expect(fiveNineteen.includes(results[518])).to.equal(true);
+        expect(fiveSixtySeven.includes(results[566])).to.equal(true);
+        expect(fiveEightyNine.includes(results[588])).to.equal(true);
         expect(fiveNinetyEight.includes(results[597])).to.equal(true)
-    })
+    });
 
     const sixHundredSeven = ["six hundred seven", "six-hundred-seven"];
     const sixTwentyNine = ["six hundred twenty nine", "six-hundred-twenty-nine"];
@@ -142,11 +142,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 600 - 700", function() {
         expect(sixHundredSeven.includes(results[606])).to.equal(true);
-        expect(sixTwentyNine.includes(results[628])).to.equal(true)
-        expect(sixFortySix.includes(results[645])).to.equal(true)
-        expect(sixSixtyEight.includes(results[667])).to.equal(true)
+        expect(sixTwentyNine.includes(results[628])).to.equal(true);
+        expect(sixFortySix.includes(results[645])).to.equal(true);
+        expect(sixSixtyEight.includes(results[667])).to.equal(true);
         expect(sixEightyTwo.includes(results[681])).to.equal(true)
-    })
+    });
 
     const sevenThirtyTwo = ["seven hundred thirty two", "seven-hundred-thirty-two"];
     const sevenFortyOne = ["seven hundred forty one", "seven-hundred-forty-one"];
@@ -156,11 +156,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 700 - 800", function() {
         expect(sevenThirtyTwo.includes(results[731])).to.equal(true);
-        expect(sevenFortyOne.includes(results[740])).to.equal(true)
-        expect(sevenSixtyEight.includes(results[767])).to.equal(true)
-        expect(sevenNinetySix.includes(results[795])).to.equal(true)
+        expect(sevenFortyOne.includes(results[740])).to.equal(true);
+        expect(sevenSixtyEight.includes(results[767])).to.equal(true);
+        expect(sevenNinetySix.includes(results[795])).to.equal(true);
         expect(sevenNinetyNine.includes(results[798])).to.equal(true)
-    })
+    });
 
     const eightHundredEight = ["eight hundred eight", "eight-hundred-eight"];
     const eightThirtySeven = ["eight hundred thirty seven", "eight-hundred-thirty-seven"];
@@ -170,11 +170,11 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 800 - 900", function() {
         expect(eightHundredEight.includes(results[807])).to.equal(true);
-        expect(eightThirtySeven.includes(results[836])).to.equal(true)
-        expect(eightFiftyNine.includes(results[858])).to.equal(true)
-        expect(eightSeventySix.includes(results[875])).to.equal(true)
+        expect(eightThirtySeven.includes(results[836])).to.equal(true);
+        expect(eightFiftyNine.includes(results[858])).to.equal(true);
+        expect(eightSeventySix.includes(results[875])).to.equal(true);
         expect(eightEightyEight.includes(results[887])).to.equal(true)
-    })
+    });
 
     const nineHundredTwo = ["nine hundred two", "nine-hundred-two"];
     const nineSeventeen = ["nine hundred seventeen", "nine-hundred-seventeen"];
@@ -184,14 +184,14 @@ describe("Numbers To Words, write a function that returns an array with all the 
 
     it("Returns 5 values correctly between 900 - 999", function() {
         expect(nineHundredTwo.includes(results[901])).to.equal(true);
-        expect(nineSeventeen.includes(results[916])).to.equal(true)
-        expect(nineFiftyFive.includes(results[954])).to.equal(true)
-        expect(nineSeventyNine.includes(results[978])).to.equal(true)
+        expect(nineSeventeen.includes(results[916])).to.equal(true);
+        expect(nineFiftyFive.includes(results[954])).to.equal(true);
+        expect(nineSeventyNine.includes(results[978])).to.equal(true);
         expect(nineEightyEight.includes(results[987])).to.equal(true)
-    })
+    });
 
     it("Last value in results is 1000", function() {
         expect(oneThousand.includes(results[999])).to.equal(true)
     })
 }
-})
+});


### PR DESCRIPTION
Changed testing from using Expect functions to using Assign functions to give more detailed errors when a test fails.

Example:
Previous test function on failure:
``` 
Expected :true
Actual   :false
 <Click to see difference>

    at Context.<anonymous> (test.js:72:20)
```

New test function on failure:
```
AssertionError: expected [ 'two hundred', 'two-hundred' ] to include 'not-two hundred'
    at Context.<anonymous> (test.js:72:20)
```